### PR TITLE
Cleanup

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,12 +1,12 @@
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 
-import App from './App.tsx'
-import Home from './pages/Home.tsx'
-import Error from './pages/Error.tsx'
-import Landing from './pages/Landing.tsx'
-import Login from './pages/Login.tsx'
-import SignUp from './pages/Signup.tsx'
+import App from './App.js'
+import Home from './pages/Home.js'
+import Error from './pages/Error.js'
+import Landing from './pages/Landing.js'
+import Login from './pages/Login.js'
+import SignUp from './pages/SignUp.js'
 
 const router = createBrowserRouter([
   {

--- a/client/src/pages/BookProgress.tsx
+++ b/client/src/pages/BookProgress.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useQuery, useMutation } from '@apollo/client';
-import { GET_BOOK_PROGRESS, UPDATE_BOOK_PROGRESS } from '../utils/queries';
+import { GET_BOOK_PROGRESS } from '../utils/queries';
+import { UPDATE_BOOK_PROGRESS } from '../utils/mutations';
 
 const BookProgress: React.FC = () => {
   const { data, loading } = useQuery(GET_BOOK_PROGRESS, { variables: { bookId: 'some-book-id' } });

--- a/client/src/pages/Error.tsx
+++ b/client/src/pages/Error.tsx
@@ -1,8 +1,9 @@
 const Error = () => {
 
     return (
-        <>
-        </>
+        <h2>
+            Whoops! Something went wrong.
+        </h2>
     )
 }
 

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -30,7 +30,7 @@ const ProfilePage: React.FC = () => {
       <section>
         <h2>My Clubs</h2>
         <ul>
-          {user?.groups.map((group) => (
+          {user?.groups.map((group: any) => (
             <li key={group._id}>
               <p>{group.groupname}</p>
               <p>{group.description}</p>
@@ -39,7 +39,7 @@ const ProfilePage: React.FC = () => {
         </ul>
       </section>
 
-      <button onClick={() => /* handle logout */ }>Logout</button>
+      <button onClick={() => {}/* handle logout */ }>Logout</button>
     </div>
   );
 };

--- a/client/src/utils/mutations.ts
+++ b/client/src/utils/mutations.ts
@@ -29,10 +29,10 @@ export const ADD_BOOK=gql`
         title
         review {
           content
-          progress
           shared
           username
         }
+        progress
       }
     }
 `
@@ -48,10 +48,92 @@ export const UPDATE_REVIEW=gql`
         title
         review {
           content
-          progress
           shared
           username
         }
+        progress
       }
     }
+`
+
+// Adds a new user to the database.
+export const ADD_USER = gql`
+  mutation AddUser($name: String!, $email: String!, $password: String!) {
+    addUser(name: $name, email: $email, password: $password) {
+      _id
+      name
+      email
+    }
+  }
+`;
+
+// Adds a new message to a club's discussion.
+export const CREATE_DISCUSSION = gql`
+  mutation CreateDiscussion($groupId: ID!, $title: String!, $image: String, $authors: [String]) {
+    createDiscussion(groupId: $groupId, title: $title, image: $image, authors: $authors) {
+      _id
+      title
+      image
+      authors
+      comments {
+        commentId
+        content
+        username
+      }
+    }
+  }
+`;
+
+// Updates progress on a specific book.
+export const UPDATE_BOOK_PROGRESS = gql`
+  mutation AddBookProgress($bookId: ID!) {
+    addBookProgress(bookId: $bookId) {
+      _id
+      progress
+      image
+      bookId
+      authors
+      title
+    }
+  }
+`;
+
+// Creates group, adds creator to users array
+export const CREATE_GROUP = gql`
+  mutation CreateGroup($groupname: String!, $leader: ID!, $description: String) {
+    createGroup(groupname: $groupname, leader: $leader, description: $description) {
+      _id
+      description
+      groupname
+    }
+  }
+`
+
+// Creates comments, adds to discussion array
+export const CREATE_COMMENT = gql`
+  mutation CreateComment($disussionId: ID!, $content: String, $username: String) {
+    createComment(disussionId: $disussionId, content: $content, username: $username) {
+      comments {
+        commentId
+        content
+        username
+      }
+      _id
+    }
+  }
+`
+
+// Adds user to group, updates group user array
+export const ADD_USER_TO_GROUP = gql`
+  mutation AddUserToGroup($userId: ID!) {
+    addUserToGroup(userId: $userId) {
+      _id
+      groupname
+      description
+      users {
+        _id
+        username
+      }
+    }
+  }
 `

--- a/client/src/utils/queries.ts
+++ b/client/src/utils/queries.ts
@@ -11,11 +11,11 @@ export const GET_MY_BOOKS=gql`
           image
           review {
             content
-            progress
             shared
             username
           }
           title
+          progress
         }
       }
     }
@@ -32,10 +32,10 @@ export const GET_ONE_BOOK=gql`
         title
         review {
           content
-          progress
           shared
           username
         }
+        progress
       }
     }
 `
@@ -66,21 +66,23 @@ export const GET_BOOK_REVIEWS=gql`
 `
 // Gets user information by ID. Used for Profile page.
 export const GET_USER = gql`
-  query getUser($id: ID!) {
-    getUser(id: $id) {
+  query getUser($getUserId: ID!) {
+    getUser(id: $getUserId) {
       _id
-      name
+      username
       email
-      favoriteBooks {
+      groups {
+        _id
+        groupname
+        description
+      }
+      books {
         _id
         title
-        author
+        authors
+        image
         progress
-      }
-      clubMemberships {
-        _id
-        name
-        description
+        bookId
       }
     }
   }
@@ -88,15 +90,21 @@ export const GET_USER = gql`
 
 // Gets club details by club ID. Used for Club page.
 export const GET_CLUB = gql`
-  query getClub($clubId: ID!) {
-    getClub(id: $clubId) {
+  query getClub($getClubId: ID!) {
+    getClub(id: $getClubId) {
       _id
-      name
+      groupname
       description
-      members {
-        _id
-        name
+      users {
+        username
         email
+        _id
+      }
+      discussions {
+        title
+        _id
+        image
+        authors
       }
     }
   }
@@ -107,73 +115,28 @@ export const GET_DISCUSSIONS = gql`
   query getDiscussions($clubId: ID!) {
     getDiscussions(clubId: $clubId) {
       _id
-      clubId
-      bookId
-      userId
-      message
-      timestamp
+      title
+      image
+      authors
+      comments {
+        commentId
+        content
+        username
+      }
     }
   }
 `;
 
 // Gets progress of a specific book by its ID. Used for Book Progress page.
 export const GET_BOOK_PROGRESS = gql`
-  query getBookProgress($bookId: ID!) {
-    getBookProgress(bookId: $bookId) {
+  query getBookProgress($id: ID!) {
+    getBook(_id: $id) {
       _id
       title
-      author
-      progress
-    }
-  }
-`;
-
-// Adds a new user to the database.
-export const ADD_USER = gql`
-  mutation addUser($name: String!, $email: String!, $password: String!) {
-    addUser(name: $name, email: $email, password: $password) {
-      _id
-      name
-      email
-    }
-  }
-`;
-
-// Adds a new message to a club's discussion.
-export const ADD_DISCUSSION = gql`
-  mutation addDiscussion($clubId: ID!, $bookId: ID!, $userId: ID!, $message: String!) {
-    addDiscussion(clubId: $clubId, bookId: $bookId, userId: $userId, message: $message) {
-      _id
-      clubId
+      authors
+      image
       bookId
-      userId
-      message
-      timestamp
-    }
-  }
-`;
-
-// Updates progress on a specific book.
-export const UPDATE_BOOK_PROGRESS = gql`
-  mutation addBookProgress($bookId: ID!, $progress: Int!) {
-    addBookProgress(bookId: $bookId, progress: $progress) {
-      _id
-      title
       progress
     }
   }
 `;
-
-export default {
-  GET_MY_BOOKS,
-  GET_ONE_BOOK,
-  GOOGLE_BOOK_SEARCH,
-  GET_BOOK_REVIEWS,
-  GET_USER,
-  GET_CLUB,
-  GET_DISCUSSIONS,
-  GET_BOOK_PROGRESS,
-  ADD_USER,
-  ADD_DISCUSSION,
-  UPDATE_BOOK_PROGRESS,
-};

--- a/server/src/models/book.ts
+++ b/server/src/models/book.ts
@@ -9,6 +9,7 @@ export interface IBook extends Document {
     image: string;
     review: typeof Review;
     bookId: string;
+    progress: number
 }
 
 const bookSchema = new Schema<IBook>(
@@ -30,6 +31,9 @@ const bookSchema = new Schema<IBook>(
             type: String,
             required: true,
             unique: true
+        },
+        progress: {
+            type: Number
         }
     }
 )

--- a/server/src/models/discussion.ts
+++ b/server/src/models/discussion.ts
@@ -1,7 +1,7 @@
 // discussions will contains a book and an array of comments
 // comments will be a subdocument that contains an id, content, and a username string
 
-import { Schema, model, Document, Types, ObjectId } from "mongoose";
+import { Schema, model, Document, Types } from "mongoose";
 
 interface IComment extends Document {
     commentId: Schema.Types.ObjectId;
@@ -10,7 +10,9 @@ interface IComment extends Document {
 }
 
 interface IDiscussion extends Document {
-    book: ObjectId;
+    title: string;
+    authors: string[];
+    image: string;
     comments: Schema.Types.ObjectId[];
 }
 
@@ -33,9 +35,15 @@ const commentSchema =  new Schema<IComment>(
 
 const discussionSchema = new Schema<IDiscussion>(
     {
-        book: {
-            type: Schema.Types.ObjectId,
-            ref: 'Book'
+        title: {
+            type: String,
+            required: true
+        },
+        authors: {
+            type: [String]
+        },
+        image: {
+            type: String
         },
         comments: {
             type: [commentSchema]

--- a/server/src/models/group.ts
+++ b/server/src/models/group.ts
@@ -6,6 +6,7 @@ interface IGroup extends Document {
     groupname: string;
     users: ObjectId[];
     discussions: ObjectId[];
+    description: String;
 }
 
 const groupSchema = new Schema<IGroup>(
@@ -22,7 +23,10 @@ const groupSchema = new Schema<IGroup>(
         discussions:[{
             type: Schema.Types.ObjectId,
             ref: 'Discussion'
-        }]
+        }],
+        description: {
+            type: String
+        }
     }
 )
 

--- a/server/src/models/review.ts
+++ b/server/src/models/review.ts
@@ -5,7 +5,6 @@ import { Schema, Document } from "mongoose";
 interface IReview extends Document {
     content: string;
     username: string;
-    progress: string;
     shared: boolean;
 }
 
@@ -16,9 +15,6 @@ const reviewSchema = new Schema<IReview>(
         },
         username: {
             type: String,
-        },
-        progress: {
-            type: String
         },
         shared: {
             type: Boolean

--- a/server/src/schemas/resolvers.ts
+++ b/server/src/schemas/resolvers.ts
@@ -65,7 +65,7 @@ const resolvers = {
         },
         // read single group: arg name, return group object
         getClub: async (_parent: any, { id }: any) => {
-            return await Group.findById(id).populate('users').populate('discussions', 'users');
+            return await Group.findById(id).populate('users').populate(['discussions', 'users']);
         },
         // read single discussion: arg discussion id, return discussion object
         getDiscussion: async (_parent: any, { clubId }: any) => {

--- a/server/src/schemas/typeDefs.ts
+++ b/server/src/schemas/typeDefs.ts
@@ -20,7 +20,6 @@ type Book {
 type Review {
     content: String
     username: String
-    progress: String
     shared: Boolean
 }
 
@@ -34,7 +33,9 @@ type Group {
 
 type Discussion {
     _id: ID
-    book: Book
+    title: String!
+    authors: [String]
+    image: String
     comments: [Comment]
 }
 
@@ -55,16 +56,17 @@ type Query {
     bookReviews(bookId: String!): [Book]
     bookSearch(string: String!): [Book]
     getClub(id: ID!): Group
-    getDiscussions(clubId: ID!): [Discussion]
-    getBookProgress(bookId: ID!): Book
+    getDiscussion(clubId: ID!): [Discussion]
 }
 
 type Mutation {
     login(email: String!, password: String!): Auth
     signup(email: String!, password: String!, username: String!): Auth
     addBook(title: String!, authors: [String], image: String, bookId: String): Book
-    updateReview(content: String, progress: String, shared: Boolean, _id: ID!): Book
-    addDiscussion(clubId: ID!, bookId: ID!, userId: ID!, message: String!): Discussion
+    updateReview(content: String, shared: Boolean, _id: ID!): Book
+    createGroup(groupname: String!, leader: ID!, description: String): Group
+    createDiscussion(groupId: ID!, title: String!, authors: [String], image: String): Discussion
+    createComment(disussionId: ID!, content: String, username: String): Discussion
     addBookProgress(bookId: ID!, progress: Int!): Book
     addUserToGroup(userId: ID!, groupId: ID!): Group
 }


### PR DESCRIPTION
Adjusted models, typedefs, and resolvers for discussion, group, and book progress. Should be fully operational on the backend now. 'Progress' is now a part of the book model, instead of a part of the review schema, makes more sense that way and works with Rolando's tech. Other than that, cleaned up a bit of imports and other small stuff.